### PR TITLE
Get ISO8601 Duration string from DateComponents

### DIFF
--- a/Sources/ISO8601DurationFormatter/DateComponents+ISO8601Duration.swift
+++ b/Sources/ISO8601DurationFormatter/DateComponents+ISO8601Duration.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @available(iOS 7.0, *)
 extension DateComponents {
-    func toISO8601Duration() -> String {
+    public func toISO8601Duration() -> String {
         var result = "P"
         result.append("\(self.year ?? 0)Y")
         result.append("\(self.month ?? 0)M")

--- a/Sources/ISO8601DurationFormatter/DateComponents+ISO8601Duration.swift
+++ b/Sources/ISO8601DurationFormatter/DateComponents+ISO8601Duration.swift
@@ -1,0 +1,24 @@
+//
+//  DateComponents+ISO8601Duration.swift
+//  
+//
+//  Created by Ahmed Moussa on 3/31/20.
+//
+
+import Foundation
+
+@available(iOS 7.0, *)
+extension DateComponents {
+    func toISO8601Duration() -> String {
+        var result = "P"
+        result.append("\(self.year ?? 0)Y")
+        result.append("\(self.month ?? 0)M")
+        result.append("\(self.weekOfYear ?? 0)W")
+        result.append("\(self.day ?? 0)D")
+        result.append("T")
+        result.append("\(self.hour ?? 0)H")
+        result.append("\(self.minute ?? 0)M")
+        result.append("\(self.second ?? 0)S")
+        return result
+    }
+}

--- a/Tests/ISO8601DurationFormatterTests/ISO8601DurationFormatterTests.swift
+++ b/Tests/ISO8601DurationFormatterTests/ISO8601DurationFormatterTests.swift
@@ -142,8 +142,16 @@ final class ISO8601DurationFormatterTests: XCTestCase {
         XCTAssertNotNil(dateComponents!.second)
         XCTAssertEqual(3, dateComponents!.second!)
     }
+    
+    func testDateComponentsToISO8601Duration() {
+        let dateComponents = DateComponents(calendar: nil, timeZone: nil, era: nil, year: 6, month: 2, day: 2, hour: 4, minute: 44, second: 22, nanosecond: nil, weekday: nil, weekdayOrdinal: nil, quarter: nil, weekOfMonth: nil, weekOfYear: 2, yearForWeekOfYear: nil)
+        let ISO8601DurationStr = dateComponents.toISO8601Duration()
+        
+        XCTAssertEqual(ISO8601DurationStr, "P6Y2M2W2DT4H44M22S")
+    }
 
     static var allTests = [
+        ("testDateComponentsToISO8601Duration", testDateComponentsToISO8601Duration),
         ("testParseComplete", testParseComplete),
         ("testParseDate", testParseDate),
         ("testParseYear", testParseYear),


### PR DESCRIPTION
- Added DateComponents extension to get ISO8601 Duration string
- Added unit test to test the function