### PR TITLE
Improved formatter and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,26 @@ And then import wherever needed: `import ISO8601DurationFormatter`
 ### Converting a string to DateComponents
 
 ```swift
-    let input = "PT40M"
-    let dateComponents = formatter.dateComponents(from: input)
-    if dateComponents != nil {
-        print(dateComponents!.minute) // 40
-    }
+let input = "PT40M"
+let dateComponents = formatter.dateComponents(from: input)
+if let dateComponents = dateComponents {
+    print(dateComponents.minute) // 40
+}
 ```
 
 ### Converting DateComponents to string
 
 ```swift
-    let dateComponents = DateComponents(year: 6, 
-                                        month: 2, 
-                                        day: 2, 
-                                        hour: 4, 
-                                        minute: 44, 
-                                        second: 22, 
-                                        weekOfYear: 2)
+let dateComponents = DateComponents(year: 6,
+                                    month: 2,
+                                    day: 2,
+                                    hour: 4,
+                                    minute: 44,
+                                    second: 22,
+                                    weekOfYear: 2)
 
-    let ISO8601DurationString = dateComponents.toISO8601Duration()
-    print(ISO8601DurationString) // P6Y2M2W2DT4H44M22S
+let ISO8601DurationString = dateComponents.toISO8601Duration()
+print(ISO8601DurationString) // P6Y2M2W2DT4H44M22S
 ```
 
 Special thanks to [Igor-Palaguta](https://github.com/Igor-Palaguta) for implementing the most in his project [YoutubeEngine](https://github.com/Igor-Palaguta/YoutubeEngine).

--- a/Sources/ISO8601DurationFormatter/ISO8601DurationFormatter.swift
+++ b/Sources/ISO8601DurationFormatter/ISO8601DurationFormatter.swift
@@ -10,16 +10,16 @@ public class ISO8601DurationFormatter: Formatter {
     
     /**
     Return a [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object created by parsing a given [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) string
-     
+
     ```
     let input = "PT40M30S"
     let dateComponents = formatter.dateComponents(from: input)
-    if dateComponents != nil {
-        print(dateComponents!.minute) // 40
-        print(dateComponents!.seconds) // 30
+    if let dateComponents = dateComponents {
+        print(dateComponents.minute) // 40
+        print(dateComponents.seconds) // 30
     }
     ```
-     
+
     - parameter string: A [String](https://developer.apple.com/documentation/swift/string) object that is parsed to generate the returned [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object.
     - returns: A  [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object created by parsing `string`, or `nil` if string could not be parsed
      */
@@ -38,67 +38,67 @@ public class ISO8601DurationFormatter: Formatter {
     
     public override func getObjectValue(_ obj: AutoreleasingUnsafeMutablePointer<AnyObject?>?, for string: String, errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?) -> Bool {
         guard let unitValues = durationUnitValues(for: string) else {
-              return false
-           }
+            return false
+        }
 
-           var components = DateComponents()
-           for (unit, value) in unitValues {
-              components.setValue(value, for: unit)
-           }
+        var components = DateComponents()
+        for (unit, value) in unitValues {
+            components.setValue(value, for: unit)
+        }
         obj?.pointee = components as AnyObject
         return true
     }
     
     private func durationUnitValues(for string: String) -> [(Calendar.Component, Int)]? {
-      guard string.hasPrefix("P") else {
-         return nil
-      }
+        guard string.hasPrefix("P") else {
+            return nil
+        }
 
-      let duration = String(string.dropFirst())
+        let duration = String(string.dropFirst())
 
-      guard let separatorRange = duration.range(of: "T") else {
-        return unitValuesWithMapping(for: duration, dateUnitMapping)
-      }
+        guard let separatorRange = duration.range(of: "T") else {
+            return unitValuesWithMapping(for: duration, dateUnitMapping)
+        }
 
-      let date = String(duration[..<separatorRange.lowerBound])
-      let time = String(duration[separatorRange.upperBound...])
+        let date = String(duration[..<separatorRange.lowerBound])
+        let time = String(duration[separatorRange.upperBound...])
 
         guard let dateUnits = unitValuesWithMapping(for: date, dateUnitMapping),
-            let timeUnits = unitValuesWithMapping(for: time, timeUnitMapping) else {
+              let timeUnits = unitValuesWithMapping(for: time, timeUnitMapping) else {
             return nil
-      }
+        }
 
-      return dateUnits + timeUnits
-   }
+        return dateUnits + timeUnits
+    }
     
     func unitValuesWithMapping(for string: String, _ mapping: [Character: Calendar.Component]) -> [(Calendar.Component, Int)]? {
-          if string.isEmpty {
-             return []
-          }
+        if string.isEmpty {
+            return []
+        }
 
-          var components: [(Calendar.Component, Int)] = []
+        var components: [(Calendar.Component, Int)] = []
 
-          let identifiersSet = CharacterSet(charactersIn: String(mapping.keys))
+        let identifiersSet = CharacterSet(charactersIn: String(mapping.keys))
 
-          let scanner = Scanner(string: string)
-          while !scanner.isAtEnd {
+        let scanner = Scanner(string: string)
+        while !scanner.isAtEnd {
             var value: Int = 0
             guard scanner.scanInt(&value) else {
                 return nil
             }
-            
-            var identifier: NSString?
-            guard scanner.scanCharacters(from: identifiersSet, into: &identifier) else {
+
+            var scannedIdentifier: NSString?
+            guard scanner.scanCharacters(from: identifiersSet, into: &scannedIdentifier) else {
                 return nil
             }
-            
-            guard identifier != nil else {
+
+            guard let identifier = scannedIdentifier as String? else {
                 return nil
             }
-            
-            let unit = mapping[Character(identifier! as String)]!
+
+            let unit = mapping[Character(identifier)]!
             components.append((unit, value))
-          }
-          return components
-       }
+        }
+        return components
+    }
 }

--- a/Tests/ISO8601DurationFormatterTests/ISO8601DurationFormatterTests.swift
+++ b/Tests/ISO8601DurationFormatterTests/ISO8601DurationFormatterTests.swift
@@ -8,139 +8,97 @@ final class ISO8601DurationFormatterTests: XCTestCase {
     override func setUp() {
         formatter = ISO8601DurationFormatter()
     }
+
+    override func tearDown() {
+        formatter = nil
+    }
     
     func testParseSecond() {
         let input = "PT5S"
         let dateComponents = formatter.dateComponents(from: input)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.second)
-        XCTAssertEqual(5, dateComponents!.second!)
+
+        XCTAssertEqual(5, dateComponents?.second)
     }
     
     func testParseMinute() {
         let input = "PT40M"
         let dateComponents = formatter.dateComponents(from: input)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.minute)
-        XCTAssertEqual(40, dateComponents!.minute!)
+
+        XCTAssertEqual(40, dateComponents?.minute)
     }
     
     func testParseHour() {
         let input = "PT1H"
         let dateComponents = formatter.dateComponents(from: input)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.hour)
-        XCTAssertEqual(1, dateComponents!.hour!)
+
+        XCTAssertEqual(1, dateComponents?.hour)
     }
     
     func testParseTime() {
         let input = "PT1H40M45S"
         let dateComponents = formatter.dateComponents(from: input)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.hour)
-        XCTAssertEqual(1, dateComponents!.hour!)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.minute)
-        XCTAssertEqual(40, dateComponents!.minute!)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.second)
-        XCTAssertEqual(45, dateComponents!.second!)
+
+        XCTAssertEqual(1, dateComponents?.hour)
+        XCTAssertEqual(40, dateComponents?.minute)
+        XCTAssertEqual(45, dateComponents?.second)
     }
     
     func testParseDay() {
         let input = "P20D"
         let dateComponents = formatter.dateComponents(from: input)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.day)
-        XCTAssertEqual(20, dateComponents!.day!)
+
+        XCTAssertEqual(20, dateComponents?.day)
     }
     
     func testParseWeek() {
         let input = "P1W"
         let dateComponents = formatter.dateComponents(from: input)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.weekOfYear)
-        XCTAssertEqual(1, dateComponents!.weekOfYear!)
+
+        XCTAssertEqual(1, dateComponents?.weekOfYear)
     }
     
     func testParseMonth() {
         let input = "P3M"
         let dateComponents = formatter.dateComponents(from: input)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.month)
-        XCTAssertEqual(3, dateComponents!.month!)
+
+        XCTAssertEqual(3, dateComponents?.month)
     }
     
     func testParseYear() {
         let input = "P6Y"
         let dateComponents = formatter.dateComponents(from: input)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.year)
-        XCTAssertEqual(6, dateComponents!.year!)
+
+        XCTAssertEqual(6, dateComponents?.year)
     }
     
     func testParseDate() {
         let input = "P6Y3M1W20D"
         let dateComponents = formatter.dateComponents(from: input)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.year)
-        XCTAssertEqual(6, dateComponents!.year!)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.month)
-        XCTAssertEqual(3, dateComponents!.month!)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.weekOfYear)
-        XCTAssertEqual(1, dateComponents!.weekOfYear!)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.day)
-        XCTAssertEqual(20, dateComponents!.day!)
+
+        XCTAssertEqual(6, dateComponents?.year)
+        XCTAssertEqual(3, dateComponents?.month)
+        XCTAssertEqual(1, dateComponents?.weekOfYear)
+        XCTAssertEqual(20, dateComponents?.day)
     }
     
     func testParseComplete() {
         let input = "P6Y3M1W20DT3H40M3S"
         let dateComponents = formatter.dateComponents(from: input)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.year)
-        XCTAssertEqual(6, dateComponents!.year!)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.month)
-        XCTAssertEqual(3, dateComponents!.month!)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.weekOfYear)
-        XCTAssertEqual(1, dateComponents!.weekOfYear!)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.day)
-        XCTAssertEqual(20, dateComponents!.day!)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.hour)
-        XCTAssertEqual(3, dateComponents!.hour!)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.minute)
-        XCTAssertEqual(40, dateComponents!.minute!)
-        
-        XCTAssertNotNil(dateComponents)
-        XCTAssertNotNil(dateComponents!.second)
-        XCTAssertEqual(3, dateComponents!.second!)
+
+        XCTAssertEqual(6, dateComponents?.year)
+        XCTAssertEqual(3, dateComponents?.month)
+        XCTAssertEqual(1, dateComponents?.weekOfYear)
+        XCTAssertEqual(20, dateComponents?.day)
+        XCTAssertEqual(3, dateComponents?.hour)
+        XCTAssertEqual(40, dateComponents?.minute)
+        XCTAssertEqual(3, dateComponents?.second)
+    }
+
+    func testParsingInvalidStringReturnsNil() {
+        let input = "XXX"
+        let dateComponents = formatter.dateComponents(from: input)
+
+        XCTAssertNil(dateComponents)
     }
     
     func testDateComponentsToISO8601Duration() {


### PR DESCRIPTION
- Made the formatting consistent in `ISO8601DurationFormatter`
- Used optional binding instead of force unwrapping
- Removed redundant asserts
    - i.e. in `testParseComplete` there were multiple calls to `XCTAssertNotNil(dateComponents)` checking the same thing over and over
- Simplified asserts

Changed 
``` swift
XCTAssertNotNil(dateComponents)
XCTAssertNotNil(dateComponents!.minute)
XCTAssertEqual(40, dateComponents!.minute!)
```
to

``` swift
XCTAssertEqual(40, dateComponents?.minute)
```
which is sufficient, as Swift is smart enough and automatically converts both of the arguments to the same type - in this case `Int?`, or `Optional<Int>`.