### PR TITLE
Support more specification details

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,12 @@ import PackageDescription
 
 let package = Package(
     name: "ISO8601DurationFormatter",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Sources/ISO8601DurationFormatter/DateComponents+ISO8601Duration.swift
+++ b/Sources/ISO8601DurationFormatter/DateComponents+ISO8601Duration.swift
@@ -9,58 +9,49 @@ import Foundation
 
 @available(iOS 7.0, *)
 extension DateComponents {
-    /**
-    Convert  a [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) string  object to [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents)
-     
-    ```
-    let dateComponents = DateComponents(year: 6,
-                                        month: 2,
-                                        day: 2,
-                                        hour: 4,
-                                        minute: 44,
-                                        second: 22,
-                                        weekOfYear: 2)
-
-    let ISO8601DurationString = dateComponents.toISO8601Duration()
-    print(ISO8601DurationString) // P6Y2M2W2DT4H44M22S
-    ```
-     
-    - returns: A [String](https://developer.apple.com/documentation/swift/string) object [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) format using the current instance of [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents)
-     */
-    public func toISO8601Duration() -> String {
-        if allComponentsZero {
+    /// Convert  a [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) string  object to [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents)
+    ///
+    /// ```swift
+    /// let dateComponents = DateComponents(
+    ///     year: 6,
+    ///     month: 2,
+    ///     day: 2,
+    ///     hour: 4,
+    ///     minute: 44,
+    ///     second: 22,
+    ///     weekOfYear: 2
+    /// )
+    ///
+    /// let ISO8601DurationString = dateComponents.toISO8601Duration()
+    /// print(ISO8601DurationString) // P6Y2M2W2DT4H44M22S
+    /// ```
+    /// - Parameter emitZeroValues: Defines if zero or nil values should be excluded from the resulting string
+    /// - Returns: A [String](https://developer.apple.com/documentation/swift/string) object [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) format using the current instance of [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents)
+    public func toISO8601Duration(emitZeroOrNilValues: Bool = false) -> String {
+        if allComponentsZeroOrNil && emitZeroOrNilValues {
             return "PT0S"
         }
         var result = "P"
-        result.appendIfNonZero(year, suffix: "Y")
-        result.appendIfNonZero(month, suffix: "M")
-        result.appendIfNonZero(weekOfYear, suffix: "W")
-        result.appendIfNonZero(day, suffix: "D")
-        if hour?.magnitude != 0 || minute?.magnitude != 0 || second?.magnitude != 0 {
+        result.append(year ?? 0, suffix: "Y", emitZeroValues: emitZeroOrNilValues)
+        result.append(month ?? 0, suffix: "M", emitZeroValues: emitZeroOrNilValues)
+        result.append(weekOfYear ?? 0, suffix: "W", emitZeroValues: emitZeroOrNilValues)
+        result.append(day ?? 0, suffix: "D", emitZeroValues: emitZeroOrNilValues)
+        if !allTimeComponentsZeroOrNil || !emitZeroOrNilValues {
             result.append("T")
-            result.appendIfNonZero(hour, suffix: "H")
-            result.appendIfNonZero(minute, suffix: "M")
-            result.appendIfNonZero(second, suffix: "S")
+            result.append(hour ?? 0, suffix: "H", emitZeroValues: emitZeroOrNilValues)
+            result.append(minute ?? 0, suffix: "M", emitZeroValues: emitZeroOrNilValues)
+            result.append(second ?? 0, suffix: "S", emitZeroValues: emitZeroOrNilValues)
         }
         return result
     }
 
-    private var allComponentsZero: Bool {
+    private var allComponentsZeroOrNil: Bool {
         let components = [year, month, weekOfYear, day, hour, minute, second]
-        return components.allSatisfy { $0?.magnitude ?? 0 == 0 }
+        return components.allSatisfy { ($0 ?? 0) == 0 }
     }
-
-}
-
-private extension String {
-
-    mutating func appendIfNonZero(_ dateComponentValue: Int?, suffix letter: String) {
-        guard
-            let dateComponentValue = dateComponentValue,
-            dateComponentValue.magnitude > 0 else {
-            return
-        }
-        self.append("\(dateComponentValue)\(letter)")
+    
+    private var allTimeComponentsZeroOrNil: Bool {
+        let components = [hour, minute, second]
+        return components.allSatisfy { ($0 ?? 0) == 0 }
     }
-
 }

--- a/Sources/ISO8601DurationFormatter/DateComponents+ISO8601Duration.swift
+++ b/Sources/ISO8601DurationFormatter/DateComponents+ISO8601Duration.swift
@@ -28,15 +28,39 @@ extension DateComponents {
     - returns: A [String](https://developer.apple.com/documentation/swift/string) object [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) format using the current instance of [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents)
      */
     public func toISO8601Duration() -> String {
+        if allComponentsZero {
+            return "PT0S"
+        }
         var result = "P"
-        result.append("\(self.year ?? 0)Y")
-        result.append("\(self.month ?? 0)M")
-        result.append("\(self.weekOfYear ?? 0)W")
-        result.append("\(self.day ?? 0)D")
-        result.append("T")
-        result.append("\(self.hour ?? 0)H")
-        result.append("\(self.minute ?? 0)M")
-        result.append("\(self.second ?? 0)S")
+        result.appendIfNonZero(year, suffix: "Y")
+        result.appendIfNonZero(month, suffix: "M")
+        result.appendIfNonZero(weekOfYear, suffix: "W")
+        result.appendIfNonZero(day, suffix: "D")
+        if hour?.magnitude != 0 || minute?.magnitude != 0 || second?.magnitude != 0 {
+            result.append("T")
+            result.appendIfNonZero(hour, suffix: "H")
+            result.appendIfNonZero(minute, suffix: "M")
+            result.appendIfNonZero(second, suffix: "S")
+        }
         return result
     }
+
+    private var allComponentsZero: Bool {
+        let components = [year, month, weekOfYear, day, hour, minute, second]
+        return components.allSatisfy { $0?.magnitude ?? 0 == 0 }
+    }
+
+}
+
+private extension String {
+
+    mutating func appendIfNonZero(_ dateComponentValue: Int?, suffix letter: String) {
+        guard
+            let dateComponentValue = dateComponentValue,
+            dateComponentValue.magnitude > 0 else {
+            return
+        }
+        self.append("\(dateComponentValue)\(letter)")
+    }
+
 }

--- a/Sources/ISO8601DurationFormatter/DateComponents+init.swift
+++ b/Sources/ISO8601DurationFormatter/DateComponents+init.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+@available(macOS 10.15, *)
+extension DateComponents {
+    /// The possible errors thrown while parsing a
+    public enum ISO8601ConversionErrors: Error, CustomStringConvertible, Equatable {
+        /// The ISO8601 input string contains a decimal number
+        case fractionalValuesNotSupported
+        /// The prefix is missing from the input string
+        case prefixMissing
+        /// While parsing, a invalid character appeared
+        case invalidCharacter(String, String.Index)
+        
+        public var description: String {
+            switch self {
+                case .fractionalValuesNotSupported:
+                    return "The provided string contains a decimal number, which cannot be parsed"
+                case .prefixMissing:
+                    return "The provided string does not include the P or -P prefix"
+                case .invalidCharacter(let input, let index):
+                    return "The provided string contains an invalid character at \(input.distance(from: input.startIndex, to: index))"
+            }
+        }
+    }
+    
+    /// Created a [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object by parsing a given [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) string
+    ///
+    /// ```swift
+    /// let input = "PT40M30S"
+    /// let dateComponents = try DateComponents(iso8601DurationString: input)
+    /// print(dateComponents.minute) // 40
+    /// print(dateComponents.seconds) // 30
+    /// ```
+    /// - Parameter iso8601DurationString: A [String](https://developer.apple.com/documentation/swift/string) object that is parsed to generate the returned [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object.
+    /// - Throws: DateComponents.ISO8601ConversionErrors if parsing does not work.
+    public init(iso8601DurationString: String) throws {
+        var duration = iso8601DurationString.uppercased()
+        let hasPrefixForNegtivDuration = duration.hasPrefix("-P")
+        guard duration.hasPrefix("P") || hasPrefixForNegtivDuration else {
+            throw ISO8601ConversionErrors.prefixMissing
+        }
+
+        duration = String(duration.dropFirst(hasPrefixForNegtivDuration ? 2 : 1))
+
+        guard let separatorRange = duration.range(of: "T") else {
+            self = try Self.dateComponentsWithMapping(
+                for: duration,
+                mapping: .dateUnitMapping
+            ) * (hasPrefixForNegtivDuration ? -1 : 1)
+            return
+        }
+
+        let date = String(duration[..<separatorRange.lowerBound])
+        let time = String(duration[separatorRange.upperBound...])
+
+        let dateUnits = try Self.dateComponentsWithMapping(for: date, mapping: .dateUnitMapping)
+        let timeUnits = try Self.dateComponentsWithMapping(for: time, mapping: .timeUnitMapping)
+        
+        self = (dateUnits + timeUnits) * (hasPrefixForNegtivDuration ? -1 : 1)
+    }
+    
+    private static func dateComponentsWithMapping(for string: String, mapping: [Character: Calendar.Component]) throws -> DateComponents {
+        if string.isEmpty {
+            return DateComponents()
+        }
+
+        var components: DateComponents = DateComponents()
+
+        let identifiersSet = CharacterSet(charactersIn: String(mapping.keys))
+
+        let scanner = Scanner(string: string)
+        while !scanner.isAtEnd {
+            guard let doubleValue = scanner.scanDouble() else {
+                let nextIndex = string.index(after: scanner.currentIndex)
+                throw ISO8601ConversionErrors.invalidCharacter(scanner.string, nextIndex)
+            }
+            
+            let (wholePart, fractionPart) = modf(doubleValue)
+            
+            // Throw an error for fractional representations as these are not suppored by `DateComponents`
+            guard fractionPart == 0 else {
+                throw ISO8601ConversionErrors.fractionalValuesNotSupported
+            }
+            
+            guard let scannedIdentifier = scanner.scanCharacters(from: identifiersSet) else {
+                let nextIndex = string.index(after: scanner.currentIndex)
+                throw ISO8601ConversionErrors.invalidCharacter(scanner.string, nextIndex)
+            }
+
+            let value = Int(wholePart)
+            let unit = mapping[Character(scannedIdentifier)]!
+            components.setValue(value, for: unit)
+        }
+        return components
+    }
+}

--- a/Sources/ISO8601DurationFormatter/Dictionary+mappings.swift
+++ b/Sources/ISO8601DurationFormatter/Dictionary+mappings.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+extension Dictionary where Key == Character, Value == Calendar.Component {
+    static var dateUnitMapping: Self = ["Y": .year, "M": .month, "W": .weekOfYear, "D": .day]
+    static var timeUnitMapping: Self = ["H": .hour, "M": .minute, "S": .second]
+}

--- a/Sources/ISO8601DurationFormatter/ISO8601DurationFormatter.swift
+++ b/Sources/ISO8601DurationFormatter/ISO8601DurationFormatter.swift
@@ -55,6 +55,9 @@ public class ISO8601DurationFormatter: Formatter {
     }
     
     public override func string(for obj: Any?) -> String? {
+        if let dateComponents = obj as? DateComponents {
+            return dateComponents.toISO8601Duration()
+        }
         return nil
     }
     

--- a/Sources/ISO8601DurationFormatter/ISO8601DurationFormatter.swift
+++ b/Sources/ISO8601DurationFormatter/ISO8601DurationFormatter.swift
@@ -1,59 +1,34 @@
 import Foundation
 
-/**
- A formatter that converts between durations specified by [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) values
- */
+/// A formatter that converts between durations specified by [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) values
 @available(iOS 13.0, *)
 public class ISO8601DurationFormatter: Formatter {
-
-    public enum Error: Swift.Error, LocalizedError {
-        case fractionalValuesNotSupported
-        case description(message: String)
-
-        public var errorDescription: String? {
-            switch self {
-            case .fractionalValuesNotSupported:
-                return String(describing: self)
-            case .description(let message):
-                return message
-            }
-        }
-    }
-
-    private let dateUnitMapping: [Character: Calendar.Component] = ["Y": .year, "M": .month, "W": .weekOfYear, "D": .day]
-    private let timeUnitMapping: [Character: Calendar.Component] = ["H": .hour, "M": .minute, "S": .second]
-    
-    /**
-    Return a [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object created by parsing a given [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) string
-
-    ```
-    let input = "PT40M30S"
-    let dateComponents = formatter.dateComponents(from: input)
-    if let dateComponents = dateComponents {
-        print(dateComponents.minute) // 40
-        print(dateComponents.seconds) // 30
-    }
-    ```
-
-    - parameter string: A [String](https://developer.apple.com/documentation/swift/string) object that is parsed to generate the returned [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object.
-    - returns: A  [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object created by parsing `string`, or `nil` if string could not be parsed
-     */
-    public func dateComponents(from string: String) throws -> DateComponents? {
-        var dateComponents: AnyObject?
-        var errorDescription: NSString?
-        if getObjectValue(&dateComponents, for: string, errorDescription: &errorDescription) {
-            return dateComponents as? DateComponents
-        }
-        if let errorDescription = errorDescription as? String {
-            if errorDescription == Error.fractionalValuesNotSupported.localizedDescription {
-                throw Error.fractionalValuesNotSupported
-            }
-            throw Error.description(message: errorDescription)
-        }
-        
-        return nil
+    /// Return a [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object created by parsing a given [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) string
+    ///
+    /// ```swift
+    /// let input = "PT40M30S"
+    /// let dateComponents = try formatter.dateComponents(from: input)
+    /// print(dateComponents.minute) // 40
+    /// print(dateComponents.seconds) // 30
+    /// ```
+    /// - Parameter string: A [String](https://developer.apple.com/documentation/swift/string) object that is parsed to generate the returned [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object.
+    /// - Returns: A [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object created by parsing `string`, or `nil` if string could not be parsed
+    /// - Throws: DateComponents.ISO8601ConversionErrors if parsing does not work.
+    public func dateComponents(from string: String) throws -> DateComponents {
+        return try DateComponents(iso8601DurationString: string)
     }
     
+    /// Return a [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object created by parsing a given [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) string. If the parameter obj is not a string, this method returns nil.
+    ///
+    /// ```swift
+    /// let input = "PT40M30S"
+    /// let dateComponents = formatter.string(for: input)
+    /// print(dateComponents.minute) // 40
+    /// print(dateComponents.seconds) // 30
+    /// ```
+    /// - Parameter string: A [String](https://developer.apple.com/documentation/swift/string) object that is parsed to generate the returned [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object.
+    /// - Returns: A [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object created by parsing `string`, or `nil` if string could not be parsed
+    /// - Throws: DateComponents.ISO8601ConversionErrors if parsing does not work.
     public override func string(for obj: Any?) -> String? {
         if let dateComponents = obj as? DateComponents {
             return dateComponents.toISO8601Duration()
@@ -63,91 +38,12 @@ public class ISO8601DurationFormatter: Formatter {
     
     public override func getObjectValue(_ obj: AutoreleasingUnsafeMutablePointer<AnyObject?>?, for string: String, errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?) -> Bool {
         do {
-            guard let unitValues = try durationUnitValues(for: string) else {
-                return false
-            }
-
-            var components = DateComponents()
-            for (unit, value) in unitValues {
-                components.setValue(value, for: unit)
-            }
+            let components = try DateComponents(iso8601DurationString: string)
             obj?.pointee = components as AnyObject
             return true
-        } catch(let caughtError) {
-            error?.pointee = String(describing: caughtError) as NSString
+        } catch let catchedError {
+            error?.pointee = String(describing: catchedError) as NSString
             return false
         }
-    }
-    
-    private func durationUnitValues(for string: String) throws -> [(Calendar.Component, Int)]? {
-        var duration = string.uppercased()
-        guard duration.hasPrefix("P") || duration.hasPrefix("-P") else {
-            return nil
-        }
-
-        let isNegative = duration.hasPrefix("-")
-        if isNegative {
-            duration = String(duration.dropFirst())
-        }
-
-        // Drop initial `P`
-        duration = String(duration.dropFirst())
-
-        guard let separatorRange = duration.range(of: "T") else {
-            return try unitValuesWithMapping(for: duration, mapping: dateUnitMapping, isNegative: isNegative)
-        }
-
-        let date = String(duration[..<separatorRange.lowerBound])
-        let time = String(duration[separatorRange.upperBound...])
-
-        guard let dateUnits = try unitValuesWithMapping(for: date, mapping: dateUnitMapping, isNegative: isNegative),
-              let timeUnits = try unitValuesWithMapping(for: time, mapping: timeUnitMapping, isNegative: isNegative) else {
-            return nil
-        }
-
-        return dateUnits + timeUnits
-    }
-    
-    func unitValuesWithMapping(for string: String, mapping: [Character: Calendar.Component], isNegative: Bool) throws -> [(Calendar.Component, Int)]? {
-        if string.isEmpty {
-            return []
-        }
-
-        var components: [(Calendar.Component, Int)] = []
-
-        let identifiersSet = CharacterSet(charactersIn: String(mapping.keys))
-
-        let scanner = Scanner(string: string)
-        while !scanner.isAtEnd {
-            var doubleVal: Double = 0
-            guard scanner.scanDouble(&doubleVal) else {
-                return nil
-            }
-
-            // Throw an error for fractional representations as these are not suppored by `DateComponents`
-            let isInteger = floor(doubleVal) == doubleVal
-            guard isInteger else {
-                throw Error.fractionalValuesNotSupported
-            }
-
-            var value = Int(floor(doubleVal))
-            
-            if isNegative {
-                value = -value
-            }
-
-            var scannedIdentifier: NSString?
-            guard scanner.scanCharacters(from: identifiersSet, into: &scannedIdentifier) else {
-                return nil
-            }
-
-            guard let identifier = scannedIdentifier as String? else {
-                return nil
-            }
-
-            let unit = mapping[Character(identifier)]!
-            components.append((unit, value))
-        }
-        return components
     }
 }

--- a/Sources/ISO8601DurationFormatter/ISO8601DurationFormatter.swift
+++ b/Sources/ISO8601DurationFormatter/ISO8601DurationFormatter.swift
@@ -3,6 +3,9 @@ import Foundation
 /// A formatter that converts between durations specified by [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) values
 @available(iOS 13.0, *)
 public class ISO8601DurationFormatter: Formatter {
+    /// Defines if zero or nil values should be excluded from the resulting string
+    public var emitZeroOrNilValues: Bool = false
+    
     /// Return a [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object created by parsing a given [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) string
     ///
     /// ```swift
@@ -18,24 +21,52 @@ public class ISO8601DurationFormatter: Formatter {
         return try DateComponents(iso8601DurationString: string)
     }
     
+    /// Convert a [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) string  object to [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents)
+    ///
+    /// ```swift
+    /// let dateComponents = DateComponents(
+    ///     year: 6,
+    ///     month: 2,
+    ///     day: 2,
+    ///     hour: 4,
+    ///     minute: 44,
+    ///     second: 22,
+    ///     weekOfYear: 2
+    /// )
+    ///
+    /// let string = formatter.string(from: dateComponents)
+    /// print(string) // P6Y2M2W2DT4H44M22S
+    /// ```
+    /// - Parameter dateComponents: A [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object that is parsed to create a a [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) string.
+    /// - Returns: A [String](https://developer.apple.com/documentation/swift/string) object [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) format using the current instance of [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents)
+    public func string(from dateComponents: DateComponents) -> String {
+        return dateComponents.toISO8601Duration(emitZeroOrNilValues: emitZeroOrNilValues)
+    }
+    
     /// Return a [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object created by parsing a given [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) string. If the parameter obj is not a string, this method returns nil.
     ///
     /// ```swift
     /// let input = "PT40M30S"
     /// let dateComponents = formatter.string(for: input)
-    /// print(dateComponents.minute) // 40
-    /// print(dateComponents.seconds) // 30
+    /// print(dateComponents?.minute) // 40
+    /// print(dateComponents?.seconds) // 30
     /// ```
     /// - Parameter string: A [String](https://developer.apple.com/documentation/swift/string) object that is parsed to generate the returned [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object.
     /// - Returns: A [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object created by parsing `string`, or `nil` if string could not be parsed
     /// - Throws: DateComponents.ISO8601ConversionErrors if parsing does not work.
     public override func string(for obj: Any?) -> String? {
         if let dateComponents = obj as? DateComponents {
-            return dateComponents.toISO8601Duration()
+            return dateComponents.toISO8601Duration(emitZeroOrNilValues: emitZeroOrNilValues)
         }
         return nil
     }
     
+    /// Returns by reference a [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object after creating it from a string.
+    /// - Parameters:
+    ///   - obj: A reference that will contain a [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object if the function returns true
+    ///   - string: A [String](https://developer.apple.com/documentation/swift/string) object that is parsed to generate the returned [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object.
+    ///   - error: A reference that will contain a error description if the function returns false.
+    /// - Returns: True if the function could successfully create a [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents) object. Otherwise false.
     public override func getObjectValue(_ obj: AutoreleasingUnsafeMutablePointer<AnyObject?>?, for string: String, errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?) -> Bool {
         do {
             let components = try DateComponents(iso8601DurationString: string)

--- a/Sources/ISO8601DurationFormatter/Operators.swift
+++ b/Sources/ISO8601DurationFormatter/Operators.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+extension Optional where Wrapped == Int {
+    static func +(_ lhs: Self, _ rhs: Self) -> Self {
+        if lhs == nil && rhs == nil {
+            return nil
+        }
+        return (lhs ?? 0) + (rhs ?? 0)
+    }
+    
+    static func *(_ lhs: Self, _ rhs: Int) -> Self {
+        guard let lhs = lhs else {
+            return nil
+        }
+        return lhs * rhs
+    }
+}
+
+extension DateComponents {
+    static func +(_ lhs: DateComponents, _ rhs: DateComponents) -> DateComponents {
+        var result = DateComponents()
+        result.second = lhs.second + rhs.second
+        result.minute = lhs.minute + rhs.minute
+        result.hour = lhs.hour + rhs.hour
+        result.day = lhs.day + rhs.day
+        result.weekOfYear = lhs.weekOfYear + rhs.weekOfYear
+        result.month = lhs.month + rhs.month
+        result.year = lhs.year + rhs.year
+        return result
+    }
+    
+    static func *(_ lhs: DateComponents, _ rhs: Int) -> DateComponents {
+        var result = DateComponents()
+        result.second = lhs.second * rhs
+        result.minute = lhs.minute * rhs
+        result.hour = lhs.hour * rhs
+        result.day = lhs.day * rhs
+        result.weekOfYear = lhs.weekOfYear * rhs
+        result.month = lhs.month * rhs
+        result.year = lhs.year * rhs
+        return result
+    }
+}

--- a/Sources/ISO8601DurationFormatter/String+append.swift
+++ b/Sources/ISO8601DurationFormatter/String+append.swift
@@ -1,0 +1,8 @@
+extension String {
+    mutating func append(_ value: Int, suffix: String, emitZeroValues: Bool) {
+        guard value != 0 || !emitZeroValues else {
+            return
+        }
+        self.append("\(value)\(suffix)")
+    }
+}

--- a/Tests/ISO8601DurationFormatterTests/DateComponentsTests.swift
+++ b/Tests/ISO8601DurationFormatterTests/DateComponentsTests.swift
@@ -1,0 +1,285 @@
+import XCTest
+
+@testable import ISO8601DurationFormatter
+
+final class DateComponentsTests: XCTestCase {
+    // MARK: toISO8601Duration
+    func test_toISO8601Duration() {
+        let dateComponents = DateComponents(
+            year: 6,
+            month: 2,
+            day: 2,
+            hour: 4,
+            minute: 44,
+            second: 22,
+            weekOfYear: 2
+        )
+        let ISO8601DurationStr = dateComponents.toISO8601Duration()
+        
+        XCTAssertEqual(ISO8601DurationStr, "P6Y2M2W2DT4H44M22S")
+    }
+    
+    func test_toISO8601Duration_shouldAppendAllZeroComponents_ifAllComponentsAreZero() {
+        let dateComponents = DateComponents(
+            year: 0,
+            month: 0,
+            day: 0,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            weekOfYear: 0
+        )
+        let ISO8601DurationStr = dateComponents.toISO8601Duration()
+        
+        XCTAssertEqual(ISO8601DurationStr, "P0Y0M0W0DT0H0M0S")
+    }
+    
+    func test_toISO8601Duration_shouldAppendAllZeroComponents_ifAllComponentsAreNil() {
+        let dateComponents = DateComponents(
+            year: nil,
+            month: nil,
+            day: nil,
+            hour: nil,
+            minute: nil,
+            second: nil,
+            weekOfYear: nil
+        )
+        let ISO8601DurationStr = dateComponents.toISO8601Duration()
+        
+        XCTAssertEqual(ISO8601DurationStr, "P0Y0M0W0DT0H0M0S")
+    }
+    
+    func test_toISO8601Duration_dropReturnEmptyDurationString_ifEmitZeroValuesIsTrueAndAllComponentsAreZero() {
+        let dateComponents = DateComponents(
+            year: 0,
+            month: 0,
+            day: 0,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            weekOfYear: 0
+        )
+        let ISO8601DurationStr = dateComponents.toISO8601Duration(emitZeroOrNilValues: true)
+        
+        XCTAssertEqual(ISO8601DurationStr, "PT0S")
+    }
+    
+    func test_toISO8601Duration_dropReturnEmptyDurationString_ifEmitZeroValuesIsTrueAndAllComponentsAreNil() {
+        let dateComponents = DateComponents(
+            year: nil,
+            month: nil,
+            day: nil,
+            hour: nil,
+            minute: nil,
+            second: nil,
+            weekOfYear: nil
+        )
+        let ISO8601DurationStr = dateComponents.toISO8601Duration(emitZeroOrNilValues: true)
+        
+        XCTAssertEqual(ISO8601DurationStr, "PT0S")
+    }
+    
+    func test_toISO8601Duration_shouldDropZeroComponents_ifEmitZeroValuesIsTrue() {
+        let dateComponents = DateComponents(
+            year: 0,
+            month: 1,
+            day: 1,
+            hour: 1,
+            minute: 1,
+            second: 1,
+            weekOfYear: 1
+        )
+        let ISO8601DurationStr = dateComponents.toISO8601Duration(emitZeroOrNilValues: true)
+        
+        XCTAssertEqual(ISO8601DurationStr, "P1M1W1DT1H1M1S")
+    }
+    
+    func test_toISO8601Duration_shouldDropZeroComponents_ifEmitZeroValuesIsTrueAndAComponentIsNil() {
+        let dateComponents = DateComponents(
+            year: nil,
+            month: 1,
+            day: 1,
+            hour: 1,
+            minute: 1,
+            second: 1,
+            weekOfYear: 1
+        )
+        let ISO8601DurationStr = dateComponents.toISO8601Duration(emitZeroOrNilValues: true)
+        
+        XCTAssertEqual(ISO8601DurationStr, "P1M1W1DT1H1M1S")
+    }
+    
+    func test_toISO8601Duration_shouldDropTimeComponents_ifEmitZeroValuesIsTrueAndAllTimeComponentsAreZero() {
+        let dateComponents = DateComponents(
+            year: 1,
+            month: 1,
+            day: 1,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            weekOfYear: 1
+        )
+        let ISO8601DurationStr = dateComponents.toISO8601Duration(emitZeroOrNilValues: true)
+        
+        XCTAssertEqual(ISO8601DurationStr, "P1Y1M1W1D")
+    }
+    
+    func test_toISO8601Duration_shouldDropTimeComponents_ifEmitZeroValuesIsTrueAndAllTimeComponentsAreNil() {
+        let dateComponents = DateComponents(
+            year: 1,
+            month: 1,
+            day: 1,
+            hour: nil,
+            minute: nil,
+            second: nil,
+            weekOfYear: 1
+        )
+        let ISO8601DurationStr = dateComponents.toISO8601Duration(emitZeroOrNilValues: true)
+        
+        XCTAssertEqual(ISO8601DurationStr, "P1Y1M1W1D")
+    }
+    
+    // MARK: init
+    func test_init_parseSecond() throws {
+        let input = "PT5S"
+        let dateComponents = try DateComponents(iso8601DurationString: input)
+
+        XCTAssertEqual(5, dateComponents.second)
+    }
+    
+    func test_init_parseMinute() throws {
+        let input = "PT40M"
+        let dateComponents = try DateComponents(iso8601DurationString: input)
+
+        XCTAssertEqual(40, dateComponents.minute)
+    }
+    
+    func test_init_parseHour() throws {
+        let input = "PT1H"
+        let dateComponents = try DateComponents(iso8601DurationString: input)
+
+        XCTAssertEqual(1, dateComponents.hour)
+    }
+    
+    func test_init_parseTime() throws {
+        let input = "PT1H40M45S"
+        let dateComponents = try DateComponents(iso8601DurationString: input)
+
+        XCTAssertEqual(1, dateComponents.hour)
+        XCTAssertEqual(40, dateComponents.minute)
+        XCTAssertEqual(45, dateComponents.second)
+    }
+    
+    func test_init_parseDay() throws {
+        let input = "P20D"
+        let dateComponents = try DateComponents(iso8601DurationString: input)
+
+        XCTAssertEqual(20, dateComponents.day)
+    }
+    
+    func test_init_parseWeek() throws {
+        let input = "P1W"
+        let dateComponents = try DateComponents(iso8601DurationString: input)
+
+        XCTAssertEqual(1, dateComponents.weekOfYear)
+    }
+    
+    func test_init_parseMonth() throws {
+        let input = "P3M"
+        let dateComponents = try DateComponents(iso8601DurationString: input)
+
+        XCTAssertEqual(3, dateComponents.month)
+    }
+    
+    func test_init_parseYear() throws {
+        let input = "P6Y"
+        let dateComponents = try DateComponents(iso8601DurationString: input)
+
+        XCTAssertEqual(6, dateComponents.year)
+    }
+    
+    func test_init_parseDate() throws {
+        let input = "P6Y3M1W20D"
+        let dateComponents = try DateComponents(iso8601DurationString: input)
+
+        XCTAssertEqual(6, dateComponents.year)
+        XCTAssertEqual(3, dateComponents.month)
+        XCTAssertEqual(1, dateComponents.weekOfYear)
+        XCTAssertEqual(20, dateComponents.day)
+    }
+    
+    func test_init_parseComplete() throws {
+        let input = "P6Y3M1W20DT3H40M3S"
+        let dateComponents = try DateComponents(iso8601DurationString: input)
+
+        XCTAssertEqual(6, dateComponents.year)
+        XCTAssertEqual(3, dateComponents.month)
+        XCTAssertEqual(1, dateComponents.weekOfYear)
+        XCTAssertEqual(20, dateComponents.day)
+        XCTAssertEqual(3, dateComponents.hour)
+        XCTAssertEqual(40, dateComponents.minute)
+        XCTAssertEqual(3, dateComponents.second)
+    }
+
+    func test_init_parseNegative() throws {
+        let input = "-P6Y3M1W20DT3H40M3S"
+        let dateComponents = try DateComponents(iso8601DurationString: input)
+
+        XCTAssertEqual(-6, dateComponents.year)
+        XCTAssertEqual(-3, dateComponents.month)
+        XCTAssertEqual(-1, dateComponents.weekOfYear)
+        XCTAssertEqual(-20, dateComponents.day)
+        XCTAssertEqual(-3, dateComponents.hour)
+        XCTAssertEqual(-40, dateComponents.minute)
+        XCTAssertEqual(-3, dateComponents.second)
+    }
+
+    func test_init_parseFractionFail() {
+        let input = "P1.5M22S"
+        do {
+            _ = try DateComponents(iso8601DurationString: input)
+            XCTFail("Method did not fail")
+        } catch let error as DateComponents.ISO8601ConversionErrors where error == .fractionalValuesNotSupported {
+            // Test succeeds
+        } catch {
+            XCTFail("The thrown error does not match the expected error")
+        }
+    }
+
+    func test_init_parsingMissingPrefix() {
+        let input = "6Y3M1W20DT3H40M3S"
+        do {
+            _ = try DateComponents(iso8601DurationString: input)
+            XCTFail("Method did not fail")
+        } catch let error as DateComponents.ISO8601ConversionErrors where error == .prefixMissing {
+            // Test succeeds
+        } catch {
+            XCTFail("The thrown error does not match the expected error")
+        }
+    }
+    
+    func test_init_parsingInvalidString() {
+        let input = "PSomethingElse"
+        do {
+            _ = try DateComponents(iso8601DurationString: input)
+            XCTFail("Method did not fail")
+        } catch DateComponents.ISO8601ConversionErrors.invalidCharacter(_, let index) {
+            print("\(input.distance(from: input.startIndex, to: index))")
+            XCTAssertEqual("S", input[index])
+        } catch {
+            XCTFail("The thrown error does not match the expected error")
+        }
+    }
+    
+    func test_init_parsingInvalidStringAtEnd() {
+        let input = "P5MG"
+        do {
+            _ = try DateComponents(iso8601DurationString: input)
+            XCTFail("Method did not fail")
+        } catch DateComponents.ISO8601ConversionErrors.invalidCharacter(_, let index) {
+            XCTAssertEqual("G", input[index])
+        } catch {
+            XCTFail("The thrown error does not match the expected error")
+        }
+    }
+}

--- a/Tests/ISO8601DurationFormatterTests/ISO8601DurationFormatterTests.swift
+++ b/Tests/ISO8601DurationFormatterTests/ISO8601DurationFormatterTests.swift
@@ -15,28 +15,28 @@ final class ISO8601DurationFormatterTests: XCTestCase {
     
     func testParseSecond() {
         let input = "PT5S"
-        let dateComponents = formatter.dateComponents(from: input)
+        let dateComponents = try? formatter.dateComponents(from: input)
 
         XCTAssertEqual(5, dateComponents?.second)
     }
     
     func testParseMinute() {
         let input = "PT40M"
-        let dateComponents = formatter.dateComponents(from: input)
+        let dateComponents = try? formatter.dateComponents(from: input)
 
         XCTAssertEqual(40, dateComponents?.minute)
     }
     
     func testParseHour() {
         let input = "PT1H"
-        let dateComponents = formatter.dateComponents(from: input)
+        let dateComponents = try? formatter.dateComponents(from: input)
 
         XCTAssertEqual(1, dateComponents?.hour)
     }
     
     func testParseTime() {
         let input = "PT1H40M45S"
-        let dateComponents = formatter.dateComponents(from: input)
+        let dateComponents = try? formatter.dateComponents(from: input)
 
         XCTAssertEqual(1, dateComponents?.hour)
         XCTAssertEqual(40, dateComponents?.minute)
@@ -45,35 +45,35 @@ final class ISO8601DurationFormatterTests: XCTestCase {
     
     func testParseDay() {
         let input = "P20D"
-        let dateComponents = formatter.dateComponents(from: input)
+        let dateComponents = try? formatter.dateComponents(from: input)
 
         XCTAssertEqual(20, dateComponents?.day)
     }
     
     func testParseWeek() {
         let input = "P1W"
-        let dateComponents = formatter.dateComponents(from: input)
+        let dateComponents = try? formatter.dateComponents(from: input)
 
         XCTAssertEqual(1, dateComponents?.weekOfYear)
     }
     
     func testParseMonth() {
         let input = "P3M"
-        let dateComponents = formatter.dateComponents(from: input)
+        let dateComponents = try? formatter.dateComponents(from: input)
 
         XCTAssertEqual(3, dateComponents?.month)
     }
     
     func testParseYear() {
         let input = "P6Y"
-        let dateComponents = formatter.dateComponents(from: input)
+        let dateComponents = try? formatter.dateComponents(from: input)
 
         XCTAssertEqual(6, dateComponents?.year)
     }
     
     func testParseDate() {
         let input = "P6Y3M1W20D"
-        let dateComponents = formatter.dateComponents(from: input)
+        let dateComponents = try? formatter.dateComponents(from: input)
 
         XCTAssertEqual(6, dateComponents?.year)
         XCTAssertEqual(3, dateComponents?.month)
@@ -83,7 +83,7 @@ final class ISO8601DurationFormatterTests: XCTestCase {
     
     func testParseComplete() {
         let input = "P6Y3M1W20DT3H40M3S"
-        let dateComponents = formatter.dateComponents(from: input)
+        let dateComponents = try? formatter.dateComponents(from: input)
 
         XCTAssertEqual(6, dateComponents?.year)
         XCTAssertEqual(3, dateComponents?.month)
@@ -94,9 +94,31 @@ final class ISO8601DurationFormatterTests: XCTestCase {
         XCTAssertEqual(3, dateComponents?.second)
     }
 
+    func testParseNegative() {
+        let input = "-P6Y3M1W20DT3H40M3S"
+        let dateComponents = try? formatter.dateComponents(from: input)
+
+        XCTAssertEqual(-6, dateComponents?.year)
+        XCTAssertEqual(-3, dateComponents?.month)
+        XCTAssertEqual(-1, dateComponents?.weekOfYear)
+        XCTAssertEqual(-20, dateComponents?.day)
+        XCTAssertEqual(-3, dateComponents?.hour)
+        XCTAssertEqual(-40, dateComponents?.minute)
+        XCTAssertEqual(-3, dateComponents?.second)
+    }
+
+    func testParseFractionFail() {
+        let input = "P1.5M"
+        do {
+            _ = try formatter.dateComponents(from: input)
+        } catch {
+            XCTAssertEqual(error.localizedDescription, "fractionalValuesNotSupported")
+        }
+    }
+
     func testParsingInvalidStringReturnsNil() {
         let input = "XXX"
-        let dateComponents = formatter.dateComponents(from: input)
+        let dateComponents = try? formatter.dateComponents(from: input)
 
         XCTAssertNil(dateComponents)
     }

--- a/Tests/ISO8601DurationFormatterTests/ISO8601DurationFormatterTests.swift
+++ b/Tests/ISO8601DurationFormatterTests/ISO8601DurationFormatterTests.swift
@@ -13,114 +13,16 @@ final class ISO8601DurationFormatterTests: XCTestCase {
         formatter = nil
     }
     
-    func testParseSecond() {
-        let input = "PT5S"
-        let dateComponents = try? formatter.dateComponents(from: input)
-
-        XCTAssertEqual(5, dateComponents?.second)
-    }
-    
-    func testParseMinute() {
-        let input = "PT40M"
-        let dateComponents = try? formatter.dateComponents(from: input)
-
-        XCTAssertEqual(40, dateComponents?.minute)
-    }
-    
-    func testParseHour() {
-        let input = "PT1H"
-        let dateComponents = try? formatter.dateComponents(from: input)
-
-        XCTAssertEqual(1, dateComponents?.hour)
-    }
-    
-    func testParseTime() {
-        let input = "PT1H40M45S"
-        let dateComponents = try? formatter.dateComponents(from: input)
-
-        XCTAssertEqual(1, dateComponents?.hour)
-        XCTAssertEqual(40, dateComponents?.minute)
-        XCTAssertEqual(45, dateComponents?.second)
-    }
-    
-    func testParseDay() {
-        let input = "P20D"
-        let dateComponents = try? formatter.dateComponents(from: input)
-
-        XCTAssertEqual(20, dateComponents?.day)
-    }
-    
-    func testParseWeek() {
-        let input = "P1W"
-        let dateComponents = try? formatter.dateComponents(from: input)
-
-        XCTAssertEqual(1, dateComponents?.weekOfYear)
-    }
-    
-    func testParseMonth() {
-        let input = "P3M"
-        let dateComponents = try? formatter.dateComponents(from: input)
-
-        XCTAssertEqual(3, dateComponents?.month)
-    }
-    
-    func testParseYear() {
-        let input = "P6Y"
-        let dateComponents = try? formatter.dateComponents(from: input)
-
-        XCTAssertEqual(6, dateComponents?.year)
-    }
-    
-    func testParseDate() {
-        let input = "P6Y3M1W20D"
-        let dateComponents = try? formatter.dateComponents(from: input)
-
-        XCTAssertEqual(6, dateComponents?.year)
-        XCTAssertEqual(3, dateComponents?.month)
-        XCTAssertEqual(1, dateComponents?.weekOfYear)
-        XCTAssertEqual(20, dateComponents?.day)
-    }
-    
-    func testParseComplete() {
-        let input = "P6Y3M1W20DT3H40M3S"
-        let dateComponents = try? formatter.dateComponents(from: input)
-
-        XCTAssertEqual(6, dateComponents?.year)
-        XCTAssertEqual(3, dateComponents?.month)
-        XCTAssertEqual(1, dateComponents?.weekOfYear)
-        XCTAssertEqual(20, dateComponents?.day)
-        XCTAssertEqual(3, dateComponents?.hour)
-        XCTAssertEqual(40, dateComponents?.minute)
-        XCTAssertEqual(3, dateComponents?.second)
-    }
-
-    func testParseNegative() {
-        let input = "-P6Y3M1W20DT3H40M3S"
-        let dateComponents = try? formatter.dateComponents(from: input)
-
-        XCTAssertEqual(-6, dateComponents?.year)
-        XCTAssertEqual(-3, dateComponents?.month)
-        XCTAssertEqual(-1, dateComponents?.weekOfYear)
-        XCTAssertEqual(-20, dateComponents?.day)
-        XCTAssertEqual(-3, dateComponents?.hour)
-        XCTAssertEqual(-40, dateComponents?.minute)
-        XCTAssertEqual(-3, dateComponents?.second)
-    }
-
-    func testParseFractionFail() {
-        let input = "P1.5M"
-        do {
-            _ = try formatter.dateComponents(from: input)
-        } catch {
-            XCTAssertEqual(error.localizedDescription, "fractionalValuesNotSupported")
-        }
-    }
-
-    func testParsingInvalidStringReturnsNil() {
-        let input = "XXX"
-        let dateComponents = try? formatter.dateComponents(from: input)
-
-        XCTAssertNil(dateComponents)
+    func test_getObjectValue() {
+        let input = "5M"
+        
+        var object: AnyObject?
+        var error: NSString?
+        let didSucceed = formatter.getObjectValue(&object, for: input, errorDescription: &error)
+        
+        XCTAssertFalse(didSucceed)
+        XCTAssertNil(object)
+        XCTAssertEqual(DateComponents.ISO8601ConversionErrors.prefixMissing.description, error as? String)
     }
     
     func testDateComponentsToISO8601Duration() {
@@ -129,18 +31,4 @@ final class ISO8601DurationFormatterTests: XCTestCase {
         
         XCTAssertEqual(ISO8601DurationStr, "P6Y2M2W2DT4H44M22S")
     }
-
-    static var allTests = [
-        ("testDateComponentsToISO8601Duration", testDateComponentsToISO8601Duration),
-        ("testParseComplete", testParseComplete),
-        ("testParseDate", testParseDate),
-        ("testParseYear", testParseYear),
-        ("testParseMonth", testParseMonth),
-        ("testParseWeek", testParseWeek),
-        ("testParseDay", testParseDay),
-        ("testParseTime", testParseTime),
-        ("testParseSecond", testParseSecond),
-        ("testParseMinute", testParseMinute),
-        ("testParseHour", testParseHour),
-    ]
 }


### PR DESCRIPTION
- Support negative values: 
    - `print(try! formatter.dateComponents(from: "-P2D")!.day)  // -2`
- Throw an error when trying to parse fractional values 
    - `try formatter.dateCompnonents(from: "P1.5D") // ISO8601DurationFormatter.Error.fractionalValuesNotSupported`
- Only append String elements required, or a `.zero` String (`"PT0S"`) if all elements empty
- Complete `Formatter` overrides with `string(for:)`